### PR TITLE
optimize workflow and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 src/Gemfile.lock
 src/lib
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 # ZRender Documentation
 
-## Build
+## Installation
 
-For the first time:
+Before you start and run this project, make sure you have `Nodejs` and `gulp` installed. And if you want to build the source on Windows, you will also need to install `Ruby` and `Bundler`
+
+> If you have problems installing Jekyll, please refer to [Jekyll's official site](https://jekyllrb.com/docs/installation/).
+
+Install `gulp`
+
+```
+npm i -g gulp
+```
+
+Install dependencies
 
 ```
 npm i
-npm i -g gulp
-cd src
-bundle install
 ```
 
-> If you have problem installing Jekyll, please refer to [Jekyll's official site](https://jekyllrb.com/docs/installation/).
-
-Watch asset files (css, js, ...) changes:
+Copy asset files (css, js, ...) to source directory:
 
 ```
-gulp       # copies and compresses assets
+gulp
 ```
+
+## Preview
+
+To preview docs, simply run `npm start`, then open [http://localhost:4000/](http://localhost:4000/) in your browser, you can change the default url and port in `./src/_config.yml`
+
+## Build
 
 Open another terminal window and:
 
 ```
-cd src
-jekyll b --config _config_release.yml   # build documentation to dist
+npm run build  # build documentation to dist
 ```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "zrender-doc",
   "version": "1.0.0",
   "description": "ZRender Documentation",
+  "scripts": {
+    "prestart": "bundle install --gemfile=src/Gemfile",
+    "start": "jekyll serve --source ./src",
+    "build": "jekyll b --source ./src --config ./src/_config_release.yml"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ecomfe/zrender-doc.git"

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -18,6 +18,7 @@ description: > # this means to ignore newlines until "baseurl:"
   ZRender Documentation and API
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://localhost/zrender-doc/public" # the base hostname & protocol for your site, e.g. http://example.com
+port: 4000 # change port if there is any conflict
 zrender_url: "/lib/js/zrender.min.js"
 source_url: "https://raw.githubusercontent.com/ecomfe/zrender-doc/master/src"
 


### PR DESCRIPTION
1. use `npm start` to run jekyll serve
2. bundle install will run automatically before npm start
3. use `npm run build` to run jekyll build
4. ignore `package-lock.json` generated by latest npm