### PR TITLE
:pencil2: fix typo in the build file.

### DIFF
--- a/public/api.html
+++ b/public/api.html
@@ -6093,7 +6093,7 @@
         
             <h3 id="animation">animation</h3>
 
-<p>类型：<code class="highlighter-rouge">Animatoin</code>，动画。</p>
+<p>类型：<code class="highlighter-rouge">Animation</code>，动画。</p>
 
         
             <h3 id="clear">clear()</h3>


### PR DESCRIPTION
Although the typo was fixed in the source file, it didn't build to the jekyll page.